### PR TITLE
HP-472

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -8,6 +8,7 @@ type CollateralToken @entity {
     interestRate: BigInt!
     totalBalance: BigInt!
     isValid: Boolean!
+    rate: BigInt!
 }
 
 type fxToken @entity {
@@ -17,6 +18,7 @@ type fxToken @entity {
     decimals: Int!
     totalSupply: BigInt!
     isValid: Boolean!
+    rate: BigInt!
 }
 
 type Vault @entity {

--- a/src/mappings/handle/tokens.ts
+++ b/src/mappings/handle/tokens.ts
@@ -7,6 +7,8 @@ import {
 import { CollateralToken, fxToken } from "../../types/schema";
 import { ERC20 } from "../../types/Handle/ERC20";
 
+const oneEth = BigInt.fromString("1000000000000000000");
+
 const createCollateralTokenEntity = (address: Address, handle: Handle): CollateralToken => {
   const entity = new CollateralToken(address.toHex());
   const token = ERC20.bind(address);
@@ -15,8 +17,8 @@ const createCollateralTokenEntity = (address: Address, handle: Handle): Collater
   let nameCall = token.try_name();
   entity.name = !nameCall.reverted ? nameCall.value : ""
   entity.decimals = token.decimals();
-  // Set initial rate to 1 wei to prevent division by zero errors.
-  entity.rate = BigInt.fromString("1");
+  // Set initial rate to 1 ether to prevent division by zero errors.
+  entity.rate = oneEth;
   return entity;
 };
 
@@ -28,8 +30,8 @@ const createFxTokenEntity = (address: Address): fxToken => {
   entity.decimals = token.decimals();
   let nameCall = token.try_name();
   entity.name = !nameCall.reverted ? nameCall.value : "";
-  // Set initial rate to 1 wei to prevent division by zero errors.
-  entity.rate = BigInt.fromString("1");
+  // Set initial rate to 1 ether to prevent division by zero errors.
+  entity.rate = oneEth;
   return entity;
 };
 

--- a/src/mappings/handle/tokens.ts
+++ b/src/mappings/handle/tokens.ts
@@ -1,4 +1,4 @@
-﻿import { Address } from '@graphprotocol/graph-ts';
+﻿import {Address, BigInt} from '@graphprotocol/graph-ts';
 import {
   Handle,
   ConfigureFxToken as ConfigureFxTokenEvent,
@@ -15,6 +15,8 @@ const createCollateralTokenEntity = (address: Address, handle: Handle): Collater
   let nameCall = token.try_name();
   entity.name = !nameCall.reverted ? nameCall.value : ""
   entity.decimals = token.decimals();
+  // Set initial rate to 1 wei to prevent division by zero errors.
+  entity.rate = BigInt.fromString("1");
   return entity;
 };
 
@@ -26,6 +28,8 @@ const createFxTokenEntity = (address: Address): fxToken => {
   entity.decimals = token.decimals();
   let nameCall = token.try_name();
   entity.name = !nameCall.reverted ? nameCall.value : "";
+  // Set initial rate to 1 wei to prevent division by zero errors.
+  entity.rate = BigInt.fromString("1");
   return entity;
 };
 

--- a/src/mappings/oracle.ts
+++ b/src/mappings/oracle.ts
@@ -116,10 +116,12 @@ function updateFxTokenRate(address: Address, handle: Handle): void {
   const entity = fxToken.load(address.toHex());
   if (entity == null) return;
   entity.rate = handle.getTokenPrice(address);
+  entity.save();
 }
 
 function updateCollateralTokenRate(address: Address, handle: Handle): void {
   const entity = CollateralToken.load(address.toHex());
   if (entity == null) return;
   entity.rate = handle.getTokenPrice(address);
+  entity.save();
 }


### PR DESCRIPTION
Indexes collateral and fxToken rates in their respective entities.
The initial rate is 1 ether, therefore if no price update is ever triggered by the collateral (i.e. mock with no aggregator events) , then the price will remain indexed as 1 ether per token.
### Testing
[In the subgraph](https://thegraph.com/explorer/subgraph/handle-fi/handle-kovan?version=pending), run the query below and ensure that the `rate` field is present.
```gql
{
  collateralTokens(first: 5) {
    id
    name
    symbol
    decimals
    rate
  }
  fxTokens(first: 5) {
    id
    name
    symbol
    decimals
    rate
  }
}
```